### PR TITLE
Noncached resources

### DIFF
--- a/src/oatpp-swagger/Controller.hpp
+++ b/src/oatpp-swagger/Controller.hpp
@@ -32,6 +32,7 @@
 
 #include "oatpp/parser/json/mapping/ObjectMapper.hpp"
 
+#include "oatpp/web/protocol/http/outgoing/ChunkedBody.hpp"
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
 
@@ -93,10 +94,20 @@ public:
   }
   
   ENDPOINT("GET", "/swagger/ui", getUIRoot) {
+    if(m_resources->isStreaming()) {
+      auto body = std::make_shared<oatpp::web::protocol::http::outgoing::ChunkedBody>
+          (m_resources->getResourceStream("index.html"), nullptr, 1024);
+      return OutgoingResponse::createShared(Status::CODE_200, body);
+    }
     return createResponse(Status::CODE_200, m_resources->getResource("index.html"));
   }
   
   ENDPOINT("GET", "/swagger/{filename}", getUIResource, PATH(String, filename)) {
+    if(m_resources->isStreaming()) {
+      auto body = std::make_shared<oatpp::web::protocol::http::outgoing::ChunkedBody>
+          (m_resources->getResourceStream(filename->c_str()), nullptr, 1024);
+      return OutgoingResponse::createShared(Status::CODE_200, body);
+    }
     return createResponse(Status::CODE_200, m_resources->getResource(filename->c_str()));
   }
   

--- a/src/oatpp-swagger/Resources.cpp
+++ b/src/oatpp-swagger/Resources.cpp
@@ -83,13 +83,9 @@ oatpp::String Resources::getResource(const oatpp::String& filename) {
 }
 
 std::shared_ptr<Resources::ReadCallback> Resources::getResourceStream(const oatpp::String &filename) {
-  return std::make_shared<ReadCallback>(m_resDir + filename);
-}
-
-Resources::ReadCallback::ReadCallback(const oatpp::String &file) : m_file(file) {
-  // Using the c API for a more convenient file-API then ifstream-API
-  m_stream = fopen(file->c_str(), "rb");
-  if(m_stream == nullptr) {
+  try {
+    return std::make_shared<ReadCallback>(m_resDir + filename);
+  } catch(std::runtime_error &e) {
     throw std::runtime_error(
         "[oatpp::swagger::Resources::getResource(...)]: Resource file not found. "
         "Please make sure: "
@@ -100,13 +96,16 @@ Resources::ReadCallback::ReadCallback(const oatpp::String &file) : m_file(file) 
   }
 }
 
+Resources::ReadCallback::ReadCallback(const oatpp::String &file) : m_file(file), m_stream(file->c_str()) {
+
+}
+
 data::v_io_size Resources::ReadCallback::read(void *buffer, data::v_io_size count) {
-  // By using the c-API, the read-callback becomes one single line of code:
-  return fread(buffer, 1, count, (FILE*)m_stream);
+  return m_stream.read(buffer, count);
 }
 
 Resources::ReadCallback::~ReadCallback() {
-  fclose((FILE*)m_stream);
+
 }
 
 }}

--- a/src/oatpp-swagger/Resources.cpp
+++ b/src/oatpp-swagger/Resources.cpp
@@ -23,12 +23,12 @@
  ***************************************************************************/
 
 #include "Resources.hpp"
-
+#include <stdio.h>
 #include <fstream>
 
 namespace oatpp { namespace swagger {
   
-Resources::Resources(const oatpp::String& resDir) {
+Resources::Resources(const oatpp::String& resDir, bool streaming) {
   
   if(!resDir || resDir->getSize() == 0) {
     throw std::runtime_error("[oatpp::swagger::Resources::Resources()]: Invalid resDir path. Please specify full path to oatpp-swagger/res folder");
@@ -38,6 +38,8 @@ Resources::Resources(const oatpp::String& resDir) {
   if(m_resDir->getData()[m_resDir->getSize() - 1] != '/') {
     m_resDir = m_resDir + "/";
   }
+
+  m_streaming = streaming;
 }
   
 void Resources::cacheResource(const char* fileName) {
@@ -66,6 +68,7 @@ oatpp::String Resources::loadFromFile(const char* fileName) {
 }
   
 oatpp::String Resources::getResource(const oatpp::String& filename) {
+
   auto it = m_resources.find(filename);
   if(it != m_resources.end()) {
     return it->second;
@@ -78,6 +81,32 @@ oatpp::String Resources::getResource(const oatpp::String& filename) {
                            "3. You specified correct full path to oatpp-swagger/res folder"
                            );
 }
-  
-  
+
+std::shared_ptr<Resources::ReadCallback> Resources::getResourceStream(const oatpp::String &filename) {
+  return std::make_shared<ReadCallback>(m_resDir + filename);
+}
+
+Resources::ReadCallback::ReadCallback(const oatpp::String &file) : m_file(file) {
+  // Using the c API for a more convenient file-API then ifstream-API
+  m_stream = fopen(file->c_str(), "rb");
+  if(m_stream == nullptr) {
+    throw std::runtime_error(
+        "[oatpp::swagger::Resources::getResource(...)]: Resource file not found. "
+        "Please make sure: "
+        "1. You are using correct version of oatpp-swagger. "
+        "2. oatpp-swagger/res is not empty. "
+        "3. You specified correct full path to oatpp-swagger/res folder"
+    );
+  }
+}
+
+data::v_io_size Resources::ReadCallback::read(void *buffer, data::v_io_size count) {
+  // By using the c-API, the read-callback becomes one single line of code:
+  return fread(buffer, 1, count, (FILE*)m_stream);
+}
+
+Resources::ReadCallback::~ReadCallback() {
+  fclose((FILE*)m_stream);
+}
+
 }}

--- a/src/oatpp-swagger/Resources.hpp
+++ b/src/oatpp-swagger/Resources.hpp
@@ -113,7 +113,7 @@ public:
   /**
    * Get streamed resource by filename.
    * @param filename - name of the resource file.
-   * @return - std::shared_ptr<&id:oatpp::swagger::Resources::ReadCallback;> containing resource binary data stream.
+   * @return - `std::shared_ptr` to &id:oatpp::data::stream::ReadCallback; containing resource binary data stream."
    */
   std::shared_ptr<ReadCallback> getResourceStream(const oatpp::String& filename);
 

--- a/src/oatpp-swagger/Resources.hpp
+++ b/src/oatpp-swagger/Resources.hpp
@@ -27,8 +27,10 @@
 
 #include "oatpp/core/Types.hpp"
 #include "oatpp/core/data/stream/ChunkedBuffer.hpp"
+#include "oatpp/core/data/stream/FileStream.hpp"
 
 #include <unordered_map>
+
 
 namespace oatpp { namespace swagger {
 
@@ -47,7 +49,7 @@ private:
   class ReadCallback : public oatpp::data::stream::ReadCallback {
    private:
     oatpp::String m_file;
-    void* m_stream;
+    oatpp::data::stream::FileInputStream m_stream;
 
    public:
 
@@ -111,7 +113,7 @@ public:
   /**
    * Get streamed resource by filename.
    * @param filename - name of the resource file.
-   * @return - std::shared_ptr<&id:ReadCallback;> containing resource binary data stream.
+   * @return - std::shared_ptr<&id:oatpp::swagger::Resources::ReadCallback;> containing resource binary data stream.
    */
   std::shared_ptr<ReadCallback> getResourceStream(const oatpp::String& filename);
 

--- a/src/oatpp-swagger/Resources.hpp
+++ b/src/oatpp-swagger/Resources.hpp
@@ -26,6 +26,7 @@
 #define oatpp_swagger_Resources_hpp
 
 #include "oatpp/core/Types.hpp"
+#include "oatpp/core/data/stream/ChunkedBuffer.hpp"
 
 #include <unordered_map>
 
@@ -38,15 +39,31 @@ class Resources {
 private:
   oatpp::String m_resDir;
   std::unordered_map<oatpp::String, oatpp::String> m_resources;
+  bool m_streaming;
 private:
   oatpp::String loadFromFile(const char* fileName);
   void cacheResource(const char* fileName);
+
+  class ReadCallback : public oatpp::data::stream::ReadCallback {
+   private:
+    oatpp::String m_file;
+    void* m_stream;
+
+   public:
+
+    ReadCallback(const oatpp::String& file);
+    ~ReadCallback();
+
+    data::v_io_size read(void *buffer, data::v_io_size count) override;
+
+  };
+
 public:
   /**
    * Constructor.
    * @param resDir - directory containing swagger-ui resources.
    */
-  Resources(const oatpp::String& resDir);
+  Resources(const oatpp::String& resDir, bool streaming = false);
 public:
 
   /**
@@ -74,12 +91,37 @@ public:
   }
 
   /**
+   * Stream Swagger-UI resources directly from disk.
+   * @param resDir - directory containing swagger-ui resources.
+   * @return - `std::shared_ptr` to Resources.
+   */
+  static std::shared_ptr<Resources> streamResources(const oatpp::String& resDir) {
+    auto res = std::make_shared<Resources>(resDir, true);
+
+    return res;
+  }
+
+  /**
    * Get cached resource by filename.
    * @param filename - name of the resource file.
    * @return - &id:oatpp::String; containing resource binary data.
    */
   oatpp::String getResource(const oatpp::String& filename);
-  
+
+  /**
+   * Get streamed resource by filename.
+   * @param filename - name of the resource file.
+   * @return - std::shared_ptr<&id:ReadCallback;> containing resource binary data stream.
+   */
+  std::shared_ptr<ReadCallback> getResourceStream(const oatpp::String& filename);
+
+  /**
+   * Returns true if this is a streaming ressource instance.
+   * @return
+   */
+  bool isStreaming() {
+    return m_streaming;
+  }
 };
   
 }}


### PR DESCRIPTION
As suggested in #11 
Use
```
  /**
   *  Swagger-Ui Resources (<oatpp-examples>/lib/oatpp-swagger/res)
   */
  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::Resources>, swaggerResources)([] {
    // Make sure to specify correct full path to oatpp-swagger/res folder !!!
    return oatpp::swagger::Resources::streamResources(OATPP_SWAGGER_RES_PATH);
  }());
```
Instead of `oatpp::swagger::Resources::loadRessources(OATPP_SWAGGER_RES_PATH);`