### PR TITLE
Initial implementation of defaults for swagger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
+include_directories(/home/ws1/oatpp)
+
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script
 ## use these variables to configure module installation
@@ -21,7 +23,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(OATPP_DIR_SRC "Path to oatpp module directory (sources)")
 option(OATPP_DIR_LIB "Path to directory with liboatpp (directory containing ex: liboatpp.so or liboatpp.dynlib)")
 option(OATPP_BUILD_TESTS "Build tests for this module" ON)
-option(OATPP_INSTALL "Install module binaries" ON)
+option(OATPP_INSTALL "Install module binaries" OFF)
 
 set(OATPP_MODULES_LOCATION "INSTALLED" CACHE STRING "Location where to find oatpp modules. can be [INSTALLED|EXTERNAL|CUSTOM]")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-include_directories(/home/ws1/oatpp)
-
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script
 ## use these variables to configure module installation
@@ -23,7 +21,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(OATPP_DIR_SRC "Path to oatpp module directory (sources)")
 option(OATPP_DIR_LIB "Path to directory with liboatpp (directory containing ex: liboatpp.so or liboatpp.dynlib)")
 option(OATPP_BUILD_TESTS "Build tests for this module" ON)
-option(OATPP_INSTALL "Install module binaries" OFF)
+option(OATPP_INSTALL "Install module binaries" ON)
 
 set(OATPP_MODULES_LOCATION "INSTALLED" CACHE STRING "Location where to find oatpp modules. can be [INSTALLED|EXTERNAL|CUSTOM]")
 

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -45,7 +45,7 @@ oatpp::String Generator::getEnumSchemaName(const Type* type) {
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const Void& defaultValue) {
+oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const oatpp::data::mapping::type::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForSimpleType()]: Error. Type should not be null.");
 
@@ -180,7 +180,7 @@ oatpp::Object<Schema> Generator::generateSchemaForEnum(const Type* type, bool li
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const Void& defaultValue) {
+oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const oatpp::data::mapping::type::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForType()]: Error. Type should not be null.");
 

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -102,8 +102,8 @@ oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, T
     if(!property->info.description.empty()) {
       result->description = property->info.description.c_str();
     }
-    if(!property->info.default_value.empty()) {
-      result->default_value = property->info.default_value.c_str();
+    if(!property->info.defaultValue.empty()) {
+      result->defaultValue = property->info.defaultValue.c_str();
     }
   }
 

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -102,6 +102,9 @@ oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, T
     if(!property->info.description.empty()) {
       result->description = property->info.description.c_str();
     }
+    if(!property->info.default_value.empty()) {
+      result->default_value = property->info.default_value.c_str();
+    }
   }
 
   return result;

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -45,7 +45,7 @@ oatpp::String Generator::getEnumSchemaName(const Type* type) {
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const oatpp::Any* defaultValue) {
+oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const oatpp::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForSimpleType()]: Error. Type should not be null.");
 
@@ -102,8 +102,8 @@ oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, T
     if(!property->info.description.empty()) {
       result->description = property->info.description.c_str();
     }
-    if (defaultValue != nullptr) {
-      result->defaultValue = *defaultValue;
+    if (defaultValue) {
+      result->defaultValue = defaultValue;
     }
   }
 
@@ -127,12 +127,12 @@ oatpp::Object<Schema> Generator::generateSchemaForTypeObject(const Type* type, b
     result->type = "object";
     result->properties = {};
 
-    auto instance = type->creator().get();
+    auto instance = type->creator();
     auto properties = type->propertiesGetter();
 
     for(auto* p : properties->getList()) {
-      auto defaultValue = oatpp::Any(p->get(instance));
-      result->properties[p->name] = generateSchemaForType(p->type, true, usedTypes, p, &defaultValue);
+      const auto& defaultValue = p->get(instance.get());
+      result->properties[p->name] = generateSchemaForType(p->type, true, usedTypes, p, defaultValue);
     }
 
     return result;
@@ -180,7 +180,7 @@ oatpp::Object<Schema> Generator::generateSchemaForEnum(const Type* type, bool li
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const oatpp::Any* defaultValue) {
+oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const oatpp::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForType()]: Error. Type should not be null.");
 

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -45,7 +45,7 @@ oatpp::String Generator::getEnumSchemaName(const Type* type) {
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const oatpp::data::mapping::type::Void& defaultValue) {
+oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const oatpp::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForSimpleType()]: Error. Type should not be null.");
 
@@ -180,7 +180,7 @@ oatpp::Object<Schema> Generator::generateSchemaForEnum(const Type* type, bool li
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const oatpp::data::mapping::type::Void& defaultValue) {
+oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const oatpp::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForType()]: Error. Type should not be null.");
 

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -45,7 +45,7 @@ oatpp::String Generator::getEnumSchemaName(const Type* type) {
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property) {
+oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, Type::Property* property, const Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForSimpleType()]: Error. Type should not be null.");
 
@@ -102,9 +102,10 @@ oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, T
     if(!property->info.description.empty()) {
       result->description = property->info.description.c_str();
     }
-    if(!property->info.defaultValue.empty()) {
-      result->defaultValue = property->info.defaultValue.c_str();
-    }
+    // if(!property->info.defaultValue.empty()) {
+    //   result->defaultValue = property->info.defaultValue.c_str();
+    // }
+    // Should use defaultValue but don't know how
   }
 
   return result;
@@ -127,10 +128,11 @@ oatpp::Object<Schema> Generator::generateSchemaForTypeObject(const Type* type, b
     result->type = "object";
     result->properties = {};
 
+    auto instance = type->creator();
     auto properties = type->propertiesGetter();
 
     for(auto* p : properties->getList()) {
-      result->properties[p->name] = generateSchemaForType(p->type, true, usedTypes, p);
+      result->properties[p->name] = generateSchemaForType(p->type, true, usedTypes, p, p->get(instance));
     }
 
     return result;
@@ -178,7 +180,7 @@ oatpp::Object<Schema> Generator::generateSchemaForEnum(const Type* type, bool li
 
 }
 
-oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property) {
+oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForType()]: Error. Type should not be null.");
 
@@ -199,7 +201,7 @@ oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool li
   } else if(classId == oatpp::data::mapping::type::__class::AbstractEnum::CLASS_ID.id) {
     result = generateSchemaForEnum(type, linkSchema, usedTypes, property);
   } else {
-    result = generateSchemaForSimpleType(type, property);
+    result = generateSchemaForSimpleType(type, property, defaultValue);
   }
 
   return result;

--- a/src/oatpp-swagger/oas3/Generator.hpp
+++ b/src/oatpp-swagger/oas3/Generator.hpp
@@ -69,11 +69,11 @@ private:
 
   static oatpp::String getEnumSchemaName(const Type* type);
 
-  static oatpp::Object<Schema> generateSchemaForSimpleType(const Type* type, Type::Property* property = nullptr, const oatpp::Any* defaultValue = nullptr);
+  static oatpp::Object<Schema> generateSchemaForSimpleType(const Type* type, Type::Property* property = nullptr, const oatpp::Void& defaultValue = nullptr);
   static oatpp::Object<Schema> generateSchemaForCollection_1D(const Type* type, bool linkSchema, UsedTypes& usedTypes, bool uniqueItems);
   static oatpp::Object<Schema> generateSchemaForTypeObject(const Type* type, bool linkSchema, UsedTypes& usedTypes);
   static oatpp::Object<Schema> generateSchemaForEnum(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr);
-  static oatpp::Object<Schema> generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr, const oatpp::Any* defaultValue = nullptr);
+  static oatpp::Object<Schema> generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr, const oatpp::Void& defaultValue = nullptr);
 
   static oatpp::Object<RequestBody> generateRequestBody(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);
   static Fields<Object<OperationResponse>> generateResponses(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);

--- a/src/oatpp-swagger/oas3/Generator.hpp
+++ b/src/oatpp-swagger/oas3/Generator.hpp
@@ -69,11 +69,11 @@ private:
 
   static oatpp::String getEnumSchemaName(const Type* type);
 
-  static oatpp::Object<Schema> generateSchemaForSimpleType(const Type* type, Type::Property* property = nullptr);
+  static oatpp::Object<Schema> generateSchemaForSimpleType(const Type* type, Type::Property* property = nullptr, const oatpp::Any* defaultValue = nullptr);
   static oatpp::Object<Schema> generateSchemaForCollection_1D(const Type* type, bool linkSchema, UsedTypes& usedTypes, bool uniqueItems);
   static oatpp::Object<Schema> generateSchemaForTypeObject(const Type* type, bool linkSchema, UsedTypes& usedTypes);
   static oatpp::Object<Schema> generateSchemaForEnum(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr);
-  static oatpp::Object<Schema> generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr);
+  static oatpp::Object<Schema> generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr, const oatpp::Any* defaultValue = nullptr);
 
   static oatpp::Object<RequestBody> generateRequestBody(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);
   static Fields<Object<OperationResponse>> generateResponses(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -294,6 +294,11 @@ class Schema : public oatpp::DTO {
    * Description of the field.
    */
   DTO_FIELD(String, description);
+  
+  /**
+   * Default value for the field.
+   */
+  DTO_FIELD(String, default_value);
 
   /**
    * Minimum value.

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -298,7 +298,7 @@ class Schema : public oatpp::DTO {
   /**
    * Default value for the field.
    */
-  DTO_FIELD(String, default_value);
+  DTO_FIELD(String, defaultValue);
 
   /**
    * Minimum value.

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -202,7 +202,6 @@ class ServerVariable : public oatpp::DTO {
       
       auto result = createShared();
       result->description = model->description;
-      // result->defaultValue = model->defaultValue;
       
       if(model->enumValues) {
         
@@ -298,7 +297,7 @@ class Schema : public oatpp::DTO {
   /**
    * Default value for the field.
    */
-  DTO_FIELD(String, defaultValue);
+  DTO_FIELD(Any, defaultValue, "default");
 
   /**
    * Minimum value.

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -202,7 +202,7 @@ class ServerVariable : public oatpp::DTO {
       
       auto result = createShared();
       result->description = model->description;
-      result->defaultValue = model->defaultValue;
+      // result->defaultValue = model->defaultValue;
       
       if(model->enumValues) {
         

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -32,6 +32,7 @@ class UserDto : public oatpp::DTO {
   DTO_FIELD(Int32, id);
   DTO_FIELD(String, firstName, "first-name");
   DTO_FIELD(String, lastName, "last-name");
+  DTO_FIELD(String, referral, "referral") = "direct";
   DTO_FIELD(List<String>, friends) = List<String>::createShared();
 
   DTO_FIELD(Enum<HelloEnum>, helloEnum);

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -33,9 +33,10 @@ class UserDto : public oatpp::DTO {
   DTO_FIELD(String, firstName, "first-name");
   DTO_FIELD(String, lastName, "last-name");
   DTO_FIELD(String, referral, "referral") = "direct";
+  DTO_FIELD(Int32, intVal) = 32;
   DTO_FIELD(List<String>, friends) = List<String>::createShared();
 
-  DTO_FIELD(Enum<HelloEnum>, helloEnum);
+  DTO_FIELD(Enum<HelloEnum>, helloEnum) = HelloEnum::V1;
 
 };
 


### PR DESCRIPTION
Following the issue oatpp/oatpp-swagger#23
I don't think this serves as a complete solution for the defaults in swagger, as it should match the type of the field and I implemented it as a string in all cases. The word default is quite tricky as well so I went with default_value, if anything it makes it more explicit.

This matches: https://github.com/oatpp/oatpp/pull/276

I'm open to all suggestions.