### PR TITLE
Generate swagger definitions for Fields<T>

### DIFF
--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -193,6 +193,11 @@ oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool li
     result = generateSchemaForCollection_1D(type, linkSchema, usedTypes, true);
   } else if(classId == oatpp::data::mapping::type::__class::AbstractPairList::CLASS_ID.id) {
     result = Schema::createShared();
+    // A PairList<String, T> is a Field<T> and a Field<T> is a simple JSON object
+    if (type->params.front()->classId.id == oatpp::data::mapping::type::__class::String::CLASS_ID.id) {
+      result->type = "object";
+      result->additionalProperties = generateSchemaForType(type->params.back(), linkSchema, usedTypes, property);
+    }
   } else if(classId == oatpp::data::mapping::type::__class::AbstractEnum::CLASS_ID.id) {
     result = generateSchemaForEnum(type, linkSchema, usedTypes, property);
   } else {

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -311,6 +311,11 @@ class Schema : public oatpp::DTO {
   DTO_FIELD(Fields<Object<Schema>>, properties);
 
   /**
+   * Additional properties.
+   */
+  DTO_FIELD(Object<Schema>, additionalProperties);
+
+  /**
    * Items.
    */
   DTO_FIELD(Object<Schema>, items);

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -33,6 +33,11 @@ class UserDto : public oatpp::DTO {
   DTO_FIELD(String, firstName, "first-name");
   DTO_FIELD(String, lastName, "last-name");
   DTO_FIELD(List<String>, friends) = List<String>::createShared();
+  DTO_FIELD(Fields<String>, todoList);
+  DTO_FIELD(Fields<Fields<String>>, todoTree);
+  DTO_FIELD(Fields<Int64>, numberList);
+  DTO_FIELD(Fields<Object<UserDto>>, friendsByNickname);
+  DTO_FIELD(Fields<List<String>>, taskForFriends);
 
   DTO_FIELD(Enum<HelloEnum>, helloEnum);
 


### PR DESCRIPTION
We noticed there was no OAS definitions for Fields<T> (e.g. Field<String> for a simple case).

```cpp
class UserDto : public oatpp::DTO {
  // [...]
  DTO_FIELD(Fields<String>, todoList);
  DTO_FIELD(Fields<Fields<String>>, todoTree);
  DTO_FIELD(Fields<Int64>, numberList);
  DTO_FIELD(Fields<Object<UserDto>>, friendsByNickname);
  DTO_FIELD(Fields<List<String>>, taskForFriends);
  // [...]
};
```
To generate something like:
```javascript
{
  // [...]
  "todoList": {
    "type": "object",
    "additionalProperties": {
      "type": "string"
    }
  },
  "numberList": {
    "type": "object",
    "additionalProperties": {
      "type": "integer",
      "format": "int64"
    }
  },
  "friendsByNickname": {
    "type": "object",
    "additionalProperties": {
      "$ref": "#\/components\/schemas\/UserDto"
    }
  },
  "taskForFriends": {
    "type": "object",
    "additionalProperties": {
      "type": "array",
      "items": {
        "type": "string"
      }
    }
  },
  "todoTree": {
    "type": "object",
    "additionalProperties": {
      "type": "object",
      "additionalProperties": {
        "type": "string"
      }
    }
  }
  // [...]
}

```