### PR TITLE
Print description for AbstractPairLists

### DIFF
--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -180,6 +180,24 @@ oatpp::Object<Schema> Generator::generateSchemaForEnum(const Type* type, bool li
 
 }
 
+oatpp::Object<Schema> Generator::generateSchemaForAbstractPairList(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property ) {
+  OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForTypeObject()]: Error. Type should not be null.");
+
+  auto result = Schema::createShared();
+
+  if (property != nullptr && !property->info.description.empty()) {
+    result->description = property->info.description.c_str();
+  }
+
+  // A PairList<String, T> is a Field<T> and a Field<T> is a simple JSON object
+  if (type->params.front()->classId.id == oatpp::data::mapping::type::__class::String::CLASS_ID.id) {
+    result->type = "object";
+    result->additionalProperties = generateSchemaForType(type->params.back(), linkSchema, usedTypes);
+  }
+
+  return result;
+}
+
 oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property, const oatpp::Void& defaultValue) {
 
   OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForType()]: Error. Type should not be null.");
@@ -197,12 +215,7 @@ oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool li
   } else if(classId == oatpp::data::mapping::type::__class::AbstractUnorderedSet::CLASS_ID.id) {
     result = generateSchemaForCollection_1D(type, linkSchema, usedTypes, true);
   } else if(classId == oatpp::data::mapping::type::__class::AbstractPairList::CLASS_ID.id) {
-    result = Schema::createShared();
-    // A PairList<String, T> is a Field<T> and a Field<T> is a simple JSON object
-    if (type->params.front()->classId.id == oatpp::data::mapping::type::__class::String::CLASS_ID.id) {
-      result->type = "object";
-      result->additionalProperties = generateSchemaForType(type->params.back(), linkSchema, usedTypes, property);
-    }
+    result = generateSchemaForAbstractPairList(type, linkSchema, usedTypes, property);
   } else if(classId == oatpp::data::mapping::type::__class::AbstractEnum::CLASS_ID.id) {
     result = generateSchemaForEnum(type, linkSchema, usedTypes, property);
   } else {

--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -181,7 +181,7 @@ oatpp::Object<Schema> Generator::generateSchemaForEnum(const Type* type, bool li
 }
 
 oatpp::Object<Schema> Generator::generateSchemaForAbstractPairList(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property ) {
-  OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForTypeObject()]: Error. Type should not be null.");
+  OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::generateSchemaForAbstractPairList()]: Error. Type should not be null.");
 
   auto result = Schema::createShared();
 

--- a/src/oatpp-swagger/oas3/Generator.hpp
+++ b/src/oatpp-swagger/oas3/Generator.hpp
@@ -73,6 +73,7 @@ private:
   static oatpp::Object<Schema> generateSchemaForCollection_1D(const Type* type, bool linkSchema, UsedTypes& usedTypes, bool uniqueItems);
   static oatpp::Object<Schema> generateSchemaForTypeObject(const Type* type, bool linkSchema, UsedTypes& usedTypes);
   static oatpp::Object<Schema> generateSchemaForEnum(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr);
+  static oatpp::Object<Schema> generateSchemaForAbstractPairList(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr);
   static oatpp::Object<Schema> generateSchemaForType(const Type* type, bool linkSchema, UsedTypes& usedTypes, Type::Property* property = nullptr, const oatpp::Void& defaultValue = nullptr);
 
   static oatpp::Object<RequestBody> generateRequestBody(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -35,6 +35,9 @@ class UserDto : public oatpp::DTO {
   DTO_FIELD(String, referral, "referral") = "direct";
   DTO_FIELD(Int32, intVal) = 32;
   DTO_FIELD(List<String>, friends) = List<String>::createShared();
+  DTO_FIELD_INFO(todoList) {
+    info->description = "Task title -> task description";
+  };
   DTO_FIELD(Fields<String>, todoList);
   DTO_FIELD(Fields<Fields<String>>, todoTree);
   DTO_FIELD(Fields<Int64>, numberList);


### PR DESCRIPTION
Hi,

I noticed that I could not get a `info->description` for a `Field<T>` in the `oas` file. This should fix that. 

I also took the chance to move all the `AbstractPairList` logic to a new method called `generateSchemaForAbstractPairList`.

It would be super nice to be able to compare OAS before and after and good for testing, but that seemed too complicated to do right now.

Example:
```cpp
DTO_FIELD_INFO(todoList) {
  info->description = "Task title -> task description";
};
DTO_FIELD(Fields<String>, todoList);
```
```json
"todoList": {
  "type": "object",
  "description": "Task title -> task description", // <-- This was not showing
  "additionalProperties": {
    "type": "string"
  }
},
```