### PR TITLE
Add info.pattern for String and other minor fixes

### DIFF
--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -54,6 +54,9 @@ oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, T
   auto classId = type->classId.id;
   if(classId == oatpp::data::mapping::type::__class::String::CLASS_ID.id) {
     result->type = "string";
+    if(property != nullptr && !property->info.pattern.empty()) {
+      result->pattern = property->info.pattern.c_str();
+    }
   } else if(classId == oatpp::data::mapping::type::__class::Int8::CLASS_ID.id) {
     result->type = "integer";
     result->minimum = std::numeric_limits<v_int8>::min();
@@ -95,15 +98,6 @@ oatpp::Object<Schema> Generator::generateSchemaForSimpleType(const Type* type, T
     result->type = type->classId.name;
     if(type->nameQualifier) {
       result->format = type->nameQualifier;
-    }
-  }
-
-  if(property != nullptr) {
-    if(!property->info.description.empty()) {
-      result->description = property->info.description.c_str();
-    }
-    if (defaultValue) {
-      result->defaultValue = defaultValue;
     }
   }
 
@@ -185,11 +179,7 @@ oatpp::Object<Schema> Generator::generateSchemaForAbstractPairList(const Type* t
 
   auto result = Schema::createShared();
 
-  if (property != nullptr && !property->info.description.empty()) {
-    result->description = property->info.description.c_str();
-  }
-
-  // A PairList<String, T> is a Field<T> and a Field<T> is a simple JSON object
+  // A PairList<String, T> is a Fields<T> and a Fields<T> is a simple JSON object
   if (type->params.front()->classId.id == oatpp::data::mapping::type::__class::String::CLASS_ID.id) {
     result->type = "object";
     result->additionalProperties = generateSchemaForType(type->params.back(), linkSchema, usedTypes);
@@ -222,8 +212,16 @@ oatpp::Object<Schema> Generator::generateSchemaForType(const Type* type, bool li
     result = generateSchemaForSimpleType(type, property, defaultValue);
   }
 
-  return result;
+  if(property != nullptr) {
+    if(!property->info.description.empty()) {
+      result->description = property->info.description.c_str();
+    }
+    if (defaultValue) {
+      result->defaultValue = defaultValue;
+    }
+  }
 
+  return result;
 }
 
 void Generator::addParamsToParametersList(const PathItemParameters& paramsList,

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -298,6 +298,11 @@ class Schema : public oatpp::DTO {
    * Default value for the field.
    */
   DTO_FIELD(Any, defaultValue, "default");
+  
+  /**
+   * Pattern value for the field.
+   */
+  DTO_FIELD(String, pattern, "pattern");
 
   /**
    * Minimum value.

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -37,11 +37,7 @@ class UserDto : public oatpp::DTO {
   };
   DTO_FIELD(String, referral, "referral") = "direct";
   DTO_FIELD(Int32, intVal) = 32;
-  DTO_FIELD(List<String>, friends) = [](){
-    auto defaultFriends = List<String>::createShared();
-    defaultFriends->push_back(String("me")); // :)
-    return defaultFriends;
-  }();
+  DTO_FIELD(List<String>, friends) = { "me", "he", "she" };
   DTO_FIELD_INFO(todoList) {
     info->description = "Task title -> task description";
   };

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -32,9 +32,16 @@ class UserDto : public oatpp::DTO {
   DTO_FIELD(Int32, id);
   DTO_FIELD(String, firstName, "first-name");
   DTO_FIELD(String, lastName, "last-name");
+  DTO_FIELD_INFO(referral) {
+    info->pattern = "^[^\\s]+$";
+  };
   DTO_FIELD(String, referral, "referral") = "direct";
   DTO_FIELD(Int32, intVal) = 32;
-  DTO_FIELD(List<String>, friends) = List<String>::createShared();
+  DTO_FIELD(List<String>, friends) = [](){
+    auto defaultFriends = List<String>::createShared();
+    defaultFriends->push_back(String("me")); // :)
+    return defaultFriends;
+  }();
   DTO_FIELD_INFO(todoList) {
     info->description = "Task title -> task description";
   };


### PR DESCRIPTION
1. Deduplicate info.description logic
1. Add info.pattern to Strings
1. Enable defaults for List<T> and Enum<T>
Requires: https://github.com/oatpp/oatpp/pull/282 (already merged)
```cpp
DTO_FIELD_INFO(referral) {
    info->pattern = "^[^\\s]+$"; // This is what we set to add
};
DTO_FIELD(String, referral, "referral") = "direct";
DTO_FIELD(List<String>, friends) = [](){
    auto defaultFriends = List<String>::createShared();
    defaultFriends->push_back(String("me")); // :)
    return defaultFriends;
}(); // Poor-mans default, just for testing
DTO_FIELD(Enum<HelloEnum>, helloEnum) = HelloEnum::V1; // We had it but it wasn't showing in swagger
```
```json
"referral": {
    "type": "string",
    "default": "direct",
    "pattern": "^[^\\s]+$" // <- Some tools can use this for validating the JSON
},
"friends": {
    "type": "array",
    "default": [ // <- Defaults for List<String>
        "me"
    ],
    "items": {
        "type": "string"
    }
},
"helloEnum": {
    "default": "value-1", // <- Defaults for Enum<T>
    "$ref": "#\/components\/schemas\/HelloEnum(String)"
}
```
