### PR TITLE
Implements Generator::decomposeMap for Fields<T>

### DIFF
--- a/src/oatpp-swagger/oas3/Generator.cpp
+++ b/src/oatpp-swagger/oas3/Generator.cpp
@@ -496,7 +496,14 @@ void Generator::decomposeCollection_1D(const Type* type, UsedTypes& decomposedTy
 }
 
 void Generator::decomposeMap(const Type* type, UsedTypes& decomposedTypes) {
-  // TODO
+  OATPP_ASSERT(type && "[oatpp-swagger::oas3::Generator::decomposeMap()]: Error. Type should not be null.");
+
+  // The only possible JSON representation of a PairList<A, B> is A being a String, even if an numeric one
+  if (type->params.front()->classId.id == oatpp::data::mapping::type::__class::String::CLASS_ID.id) {
+    decomposeType(type->params.back(), decomposedTypes);
+  }
+
+  // TODO - more advanced cases with complex key types
 }
 
 void Generator::decomposeEnum(const Type* type, UsedTypes& decomposedTypes) {

--- a/test/oatpp-swagger/test-controllers/TestController.hpp
+++ b/test/oatpp-swagger/test-controllers/TestController.hpp
@@ -25,6 +25,13 @@ ENUM(HelloEnum, v_int16,
      VALUE(V5, 50, "value-5", "description-5")
 )
 
+class TaskDto : public oatpp::DTO {
+  DTO_INIT(TaskDto, DTO)
+
+  DTO_FIELD(String, description);
+  DTO_FIELD(Boolean, done);
+};
+
 class UserDto : public oatpp::DTO {
 
   DTO_INIT(UserDto, DTO)
@@ -44,6 +51,7 @@ class UserDto : public oatpp::DTO {
   DTO_FIELD(Fields<String>, todoList);
   DTO_FIELD(Fields<Fields<String>>, todoTree);
   DTO_FIELD(Fields<Int64>, numberList);
+  DTO_FIELD(Fields<Object<TaskDto>>, tasksByTitle);
   DTO_FIELD(Fields<Object<UserDto>>, friendsByNickname);
   DTO_FIELD(Fields<List<String>>, taskForFriends);
 


### PR DESCRIPTION
We found out that having only a `Fields<Object<MyThing>>` reference to a DTO caused it not to show in the OAS document, but the reference to it was there and it broke all our swagger based pipeline.

This should fix the `Fields<T>` case, I can't think of other valid `PairList<A, B>` besides `PairList<String, T>` in a JSON format.

The output OAS file now looks like:
```json
"TaskDto": {
    "type": "object",
    "properties": {
        "description": {
            "type": "string"
        },
        "done": {
            "type": "boolean"
        }
    }
},
// [...]
"tasksByTitle": {
    "type": "object",
    "additionalProperties": {
        "$ref": "#\/components\/schemas\/TaskDto"
    }
},
```

It would be super nice if we could compare the before and after OAS file as a simple test implementation, I didn't know how to do it in a way that would fit the project guidelines.
