### PR TITLE
Change default SwaggerUI installation path to a more suitable place.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,14 @@ OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::DocumentInfo>, swaggerDoc
  */
 OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::Resources>, swaggerResources)([] {
   // Make sure to specify correct full path to oatpp-swagger/res folder !!!
-  return oatpp::swagger::Resources::loadResources("<YOUR-PATH-TO-REPO>/lib/oatpp-swagger/res");
+  // If you have 'installed' oatpp-swagger these folders would be:
+  // On *nix OS's SwaggerUI are installed to <install-prefix>/share/oatpp-<version>/oatpp-swagger/res/ (with <install-prefix> defaulting /usr/local).
+  // On Windows SwaggerUI areinstalled to <install-prefix>/oatpp-<version>/res/ (with <install-prefix> defaulting to "c:/Program Files/${PROJECT_NAME}")
+
+  // Uncomment to chose one of the default installation paths or select your own:
+  // return oatpp::swagger::Resources::loadResources("/usr/local/share/oatpp-1.2.5/oatpp-swagger/res");
+  // return oatpp::swagger::Resources::loadResources("c:/Program Files/oatpp-swagger/oatpp-1.2.5/res");  
+  // return oatpp::swagger::Resources::loadResources(OATPP_SWAGGER_RES_PATH);
 }());
 
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+option(OATPP_INSTALL_SWAGGER_UI "Install Swagger-UI resources" ON)
 
 add_library(${OATPP_THIS_MODULE_NAME}
         oatpp-swagger/AsyncController.hpp
@@ -36,13 +37,14 @@ target_include_directories(${OATPP_THIS_MODULE_NAME}
 if(OATPP_INSTALL)
     include("../cmake/module-install.cmake")
 
-    ## install swagger-ui files
-    install(DIRECTORY ../res
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/oatpp-${OATPP_MODULE_VERSION}/bin/${OATPP_MODULE_NAME}"
-            FILES_MATCHING PATTERN "*.*"
-    )
+    if(OATPP_INSTALL_SWAGGER_UI)
+        ## install swagger-ui files
+        install(DIRECTORY ../res
+                DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/oatpp-${OATPP_MODULE_VERSION}/bin/${OATPP_MODULE_NAME}"
+                FILES_MATCHING PATTERN "*.*"
+        )
 
-    ## set environment variable to point to swagger-ui res files
-    set(ENV{OATPP_SWAGGER_RES_PATH} "${CMAKE_INSTALL_INCLUDEDIR}/oatpp-${OATPP_MODULE_VERSION}/bin/${OATPP_MODULE_NAME}/res")
-
+        ## set environment variable to point to swagger-ui res files
+        set(ENV{OATPP_SWAGGER_RES_PATH} "${CMAKE_INSTALL_INCLUDEDIR}/oatpp-${OATPP_MODULE_VERSION}/bin/${OATPP_MODULE_NAME}/res")
+    endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,13 +38,19 @@ if(OATPP_INSTALL)
     include("../cmake/module-install.cmake")
 
     if(OATPP_INSTALL_SWAGGER_UI)
+        if (WIN32)
+            set(OATPP_SWAGGER_UI_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/oatpp-${OATPP_MODULE_VERSION}" CACHE STRING "SwaggerUI installation directory")
+        else()
+            set(OATPP_SWAGGER_UI_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/oatpp-${OATPP_MODULE_VERSION}/${OATPP_MODULE_NAME}" CACHE STRING "SwaggerUI installation directory")
+        endif()
+
         ## install swagger-ui files
         install(DIRECTORY ../res
-                DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/oatpp-${OATPP_MODULE_VERSION}/bin/${OATPP_MODULE_NAME}"
+                DESTINATION "${OATPP_SWAGGER_UI_INSTALL_DIR}"
                 FILES_MATCHING PATTERN "*.*"
         )
 
         ## set environment variable to point to swagger-ui res files
-        set(ENV{OATPP_SWAGGER_RES_PATH} "${CMAKE_INSTALL_INCLUDEDIR}/oatpp-${OATPP_MODULE_VERSION}/bin/${OATPP_MODULE_NAME}/res")
+        set(ENV{OATPP_SWAGGER_RES_PATH} "${OATPP_SWAGGER_UI_INSTALL_DIR}/res")
     endif()
 endif()


### PR DESCRIPTION
Installing SwaggerUI in the systems include path just feels wrong.
This PR moves the installation to a more expected and structured place.

On *nix OS's SwaggerUI will be installed to `<install-prefix>`/share/oatpp-`<version>`/oatpp-swagger/res/ (with `<install-prefix>` defaulting to "/usr/local").
On Windows SwaggerUI will be installed to `<install-prefix>`/oatpp-`<version>`/res/ (with `<install-prefix>` defaulting to "c:/Program Files/`${PROJECT_NAME}`").

The installation path can also be overwritten by passing -DOATPP_SWAGGER_UI_INSTALL_DIR="`<dir>`" when invoking cmake.