### PR TITLE
Fix:  Let oatpp 1.3.0 and its new string implmentation work.

### DIFF
--- a/src/oatpp-swagger/Generator.cpp
+++ b/src/oatpp-swagger/Generator.cpp
@@ -371,7 +371,6 @@ void Generator::generatePathItemData(const std::shared_ptr<Endpoint>& endpoint, 
   auto info = endpoint->info();
 
   if(info) {
-
     auto operation = oas3::PathItemOperation::createShared();
     operation->operationId = info->name;
     operation->summary = info->summary;
@@ -384,21 +383,21 @@ void Generator::generatePathItemData(const std::shared_ptr<Endpoint>& endpoint, 
       }
     }
 
-    if(oatpp::base::StrBuffer::equalsCI("get", info->method->c_str(), info->method->getSize())) {
+    if(info->method.equalsCI("GET")) {
       pathItem->operationGet = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("put", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("put")) {
       pathItem->operationPut = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("post", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("post")) {
       pathItem->operationPost = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("delete", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("delete")) {
       pathItem->operationDelete = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("options", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("options")) {
       pathItem->operationOptions = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("head", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("head")) {
       pathItem->operationHead = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("patch", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("patch")) {
       pathItem->operationPatch = operation;
-    } else if(oatpp::base::StrBuffer::equalsCI("trace", info->method->c_str(), info->method->getSize())) {
+    } else if(info->method.equalsCI("trace")) {
       pathItem->operationTrace = operation;
     }
 
@@ -471,10 +470,11 @@ Generator::Paths Generator::generatePaths(const std::shared_ptr<Endpoints>& endp
 
     if(endpoint->info() && !endpoint->info()->hide) {
       oatpp::String path = endpoint->info()->path;
-      if(path->getSize() == 0) {
+
+      if(path->size() == 0) {
         continue;
       }
-      if(path->getData()[0] != '/') {
+      if(path->at(0) != '/') {
         path = "/" + path;
       }
 
@@ -555,29 +555,29 @@ void Generator::decomposeType(const Type* type, UsedTypes& decomposedTypes) {
     decomposeEnum(type, decomposedTypes);
   }
 }
-  
+
 Generator::UsedTypes Generator::decomposeTypes(UsedTypes& usedTypes) {
-  
+
   UsedTypes result; // decomposed schemas
-  
+
   auto it = usedTypes.begin();
   while (it != usedTypes.end()) {
     decomposeType(it->second, result);
     result[it->first] = it->second;
     it ++;
   }
-  
+
   return result;
-  
+
 }
 
 oatpp::Object<oas3::Components> Generator::generateComponents(const UsedTypes &decomposedTypes,
                                                               const std::shared_ptr<std::unordered_map<oatpp::String,std::shared_ptr<oatpp::swagger::SecurityScheme>>> &securitySchemes,
                                                               UsedSecuritySchemes &usedSecuritySchemes) {
-  
+
   auto result = oas3::Components::createShared();
   result->schemas = {};
-  
+
   auto it = decomposedTypes.begin();
   while (it != decomposedTypes.end()) {
     UsedTypes schemas; ///< dummy
@@ -594,7 +594,7 @@ oatpp::Object<oas3::Components> Generator::generateComponents(const UsedTypes &d
   }
 
   return result;
-  
+
 }
 
 
@@ -668,10 +668,10 @@ Generator::Generator(const std::shared_ptr<Config>& config)
 {}
 
 oatpp::Object<oas3::Document> Generator::generateDocument(const std::shared_ptr<oatpp::swagger::DocumentInfo>& docInfo, const std::shared_ptr<Endpoints>& endpoints) {
-  
+
   auto document = oas3::Document::createShared();
   document->info = oas3::Info::createFromBaseModel(docInfo->header);
-  
+
   if(docInfo->servers) {
     document->servers = {};
 
@@ -680,7 +680,7 @@ oatpp::Object<oas3::Document> Generator::generateDocument(const std::shared_ptr<
     }
 
   }
-  
+
   UsedTypes usedTypes;
   UsedSecuritySchemes usedSecuritySchemes;
   document->paths = generatePaths(endpoints, usedTypes, usedSecuritySchemes);
@@ -688,7 +688,7 @@ oatpp::Object<oas3::Document> Generator::generateDocument(const std::shared_ptr<
   document->components = generateComponents(decomposedTypes, docInfo->securitySchemes, usedSecuritySchemes);
 
   return document;
-  
+
 }
 
 }}

--- a/src/oatpp-swagger/Resources.cpp
+++ b/src/oatpp-swagger/Resources.cpp
@@ -27,47 +27,47 @@
 #include <fstream>
 
 namespace oatpp { namespace swagger {
-  
+
 Resources::Resources(const oatpp::String& resDir, bool streaming) {
-  
-  if(!resDir || resDir->getSize() == 0) {
+
+  if(!resDir || resDir->size() == 0) {
     throw std::runtime_error("[oatpp::swagger::Resources::Resources()]: Invalid resDir path. Please specify full path to oatpp-swagger/res folder");
   }
-  
+
   m_resDir = resDir;
-  if(m_resDir->getData()[m_resDir->getSize() - 1] != '/') {
+  if(m_resDir->at(m_resDir->size() - 1) != '/') {
     m_resDir = m_resDir + "/";
   }
 
   m_streaming = streaming;
 
 }
-  
+
 void Resources::cacheResource(const char* fileName) {
   m_resources[fileName] = loadFromFile(fileName);
 }
-  
+
 oatpp::String Resources::loadFromFile(const char* fileName) {
-  
+
   auto fullFilename = m_resDir + fileName;
-  
+
   std::ifstream file (fullFilename->c_str(), std::ios::in|std::ios::binary|std::ios::ate);
-  
+
   if (file.is_open()) {
-    
+
     auto result = oatpp::String((v_int32) file.tellg());
     file.seekg(0, std::ios::beg);
-    file.read((char*)result->getData(), result->getSize());
+    file.read((char*)result->data(), result->size());
     file.close();
     return result;
-    
+
   }
-  
+
   OATPP_LOGE("oatpp::swagger::Resources::loadFromFile()", "Can't load file '%s'", fullFilename->c_str());
   throw std::runtime_error("[oatpp::swagger::Resources::loadFromFile(...)]: Can't load file. Please make sure you specified full path to oatpp-swagger/res folder");
-  
+
 }
-  
+
 oatpp::String Resources::getResource(const oatpp::String& filename) {
 
   auto it = m_resources.find(filename);

--- a/src/oatpp-swagger/Types.hpp
+++ b/src/oatpp-swagger/Types.hpp
@@ -29,7 +29,7 @@
 #include "oatpp/core/Types.hpp"
 
 namespace oatpp { namespace swagger {
-  
+
 namespace __class {
 
   /**
@@ -51,18 +51,21 @@ namespace __class {
       static oatpp::data::mapping::type::Type type(CLASS_ID, "binary");
       return &type;
     }
-    
+
   };
-  
+
 }
 
 /**
  * Typedef for Binary. It is used to indicate file upload in Swagger-UI. <br>
  * Usage example: `info->addConsumes<oatpp::swagger::Binary>("application/octet-stream");`.<br>
  * For more info see: [Endpoint Annotation And API Documentation](/docs/components/api-controller/#endpoint-annotation-and-api-documentation).
+ *
+ *
+ * warning: using a string as replacement for binary might lead to problems with the NUL-character.
  */
-typedef oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::Binary> Binary;
-  
+typedef oatpp::data::mapping::type::ObjectWrapper<oatpp::String, __class::Binary> Binary;
+
 }}
 
 #endif /* oatpp_swagger_Types_hpp */


### PR DESCRIPTION
With version 1.3.0 oatpp uses a string implementation based
on std::string. Thus, the string operations on StrBuffer need
to be replaced as well.

It uses the oatpp::String::equalsCI function. Please ensure
to upgrade oatpp to the latest 1.3.0 version before.


The PR https://github.com/oatpp/oatpp/pull/471 have to be merged before since it brings the `equalsCI` method in the string class. 