### PR TITLE
Add option to link with MSVC static runtime (OFF by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(OATPP_DIR_SRC "Path to oatpp module directory (sources)")
 option(OATPP_DIR_LIB "Path to directory with liboatpp (directory containing ex: liboatpp.so or liboatpp.dynlib)")
 option(OATPP_BUILD_TESTS "Build tests for this module" ON)
 option(OATPP_INSTALL "Install module binaries" ON)
+option(OATPP_MSVC_LINK_STATIC_RUNTIME "MSVC: Link with static runtime (/MT and /MTd)." OFF)
 
 set(OATPP_MODULES_LOCATION "INSTALLED" CACHE STRING "Location where to find oatpp modules. can be [INSTALLED|EXTERNAL|CUSTOM]")
 
@@ -99,9 +100,12 @@ message("\n#####################################################################
 
 include(cmake/module-utils.cmake)
 
-add_subdirectory("src")
+include(cmake/msvc-runtime.cmake)
+configure_msvc_runtime()
+
+add_subdirectory(src)
 
 if(OATPP_BUILD_TESTS)
     enable_testing()
-    add_subdirectory("test")
+    add_subdirectory(test)
 endif()

--- a/cmake/msvc-runtime.cmake
+++ b/cmake/msvc-runtime.cmake
@@ -1,0 +1,36 @@
+macro(configure_msvc_runtime)
+	if(MSVC)
+		# Set compiler options.
+		set(variables
+			CMAKE_C_FLAGS
+			CMAKE_C_FLAGS_DEBUG
+			CMAKE_C_FLAGS_MINSIZEREL
+			CMAKE_C_FLAGS_RELEASE
+			CMAKE_C_FLAGS_RELWITHDEBINFO
+			CMAKE_CXX_FLAGS
+			CMAKE_CXX_FLAGS_DEBUG
+			CMAKE_CXX_FLAGS_MINSIZEREL
+			CMAKE_CXX_FLAGS_RELEASE
+			CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+
+		if(OATPP_MSVC_LINK_STATIC_RUNTIME)
+			message(STATUS "MSVC: using statically-linked runtime (/MT and /MTd).")
+			foreach(variable ${variables})
+				if(${variable} MATCHES "/MD")
+					string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+				endif()
+			endforeach()
+		else()
+			message(STATUS "MSVC: using dynamically-linked runtime (/MD and /MDd).")
+			foreach(variable ${variables})
+				if(${variable} MATCHES "/MT")
+					string(REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
+				endif()
+			endforeach()
+		endif()
+
+		foreach(variable ${variables})
+			set(${variable} "${${variable}}" CACHE STRING "MSVC_${variable}" FORCE)
+		endforeach()
+	endif()
+endmacro(configure_msvc_runtime)


### PR DESCRIPTION
Hi,

here is the same need and changes that for [this PR](https://github.com/oatpp/oatpp/pull/435) for Oatpp and [this one](https://github.com/oatpp/oatpp-websocket/pull/29) for oatpp-websocket projects.

Another small change in this PR : remove quotes on CMake add_subdirectory calls