### PR TITLE
Added possibility to customize the path to the Swagger UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,13 @@ message("\n#####################################################################
 ###################################################################################################
 ## define targets
 
+set(SWAGGER_ROOT_PATH "/swagger" CACHE STRING "Default root path to the Swagger")
+set(SWAGGER_UI_PATH "/ui" CACHE STRING "Default path suffix to the Swagger UI")
+add_compile_definitions(
+    SWAGGER_ROOT_PATH="${SWAGGER_ROOT_PATH}"
+    SWAGGER_UI_PATH="${SWAGGER_UI_PATH}"
+)
+
 include(cmake/module-utils.cmake)
 
 include(cmake/msvc-runtime.cmake)

--- a/src/oatpp-swagger/AsyncController.hpp
+++ b/src/oatpp-swagger/AsyncController.hpp
@@ -35,13 +35,6 @@
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
 
-#ifndef SWAGGER_ROOT_PATH
-#define SWAGGER_ROOT_PATH "/swagger"
-#endif
-#ifndef SWAGGER_UI_PATH
-#define SWAGGER_UI_PATH "/ui"
-#endif
-
 namespace oatpp { namespace swagger {
 
 /**

--- a/src/oatpp-swagger/AsyncController.hpp
+++ b/src/oatpp-swagger/AsyncController.hpp
@@ -35,6 +35,13 @@
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
 
+#ifndef SWAGGER_ROOT_PATH
+#define SWAGGER_ROOT_PATH "/swagger"
+#endif
+#ifndef SWAGGER_UI_PATH
+#define SWAGGER_UI_PATH "/ui"
+#endif
+
 namespace oatpp { namespace swagger {
 
 /**
@@ -108,7 +115,7 @@ public:
     
   };
   
-  ENDPOINT_ASYNC("GET", "/swagger/ui", GetUIRoot) {
+  ENDPOINT_ASYNC("GET", SWAGGER_ROOT_PATH SWAGGER_UI_PATH, GetUIRoot) {
     
     ENDPOINT_ASYNC_INIT(GetUIRoot)
     
@@ -118,7 +125,7 @@ public:
     
   };
   
-  ENDPOINT_ASYNC("GET", "/swagger/{filename}", GetUIResource) {
+  ENDPOINT_ASYNC("GET", SWAGGER_ROOT_PATH "/{filename}", GetUIResource) {
     
     ENDPOINT_ASYNC_INIT(GetUIResource)
     

--- a/src/oatpp-swagger/Controller.hpp
+++ b/src/oatpp-swagger/Controller.hpp
@@ -36,6 +36,13 @@
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
 
+#ifndef SWAGGER_ROOT_PATH
+#define SWAGGER_ROOT_PATH "/swagger"
+#endif
+#ifndef SWAGGER_UI_PATH
+#define SWAGGER_UI_PATH "/ui"
+#endif
+
 namespace oatpp { namespace swagger {
 
 /**
@@ -101,7 +108,7 @@ public:
     return createDtoResponse(Status::CODE_200, m_document);
   }
   
-  ENDPOINT("GET", "/swagger/ui", getUIRoot) {
+  ENDPOINT("GET", SWAGGER_ROOT_PATH SWAGGER_UI_PATH, getUIRoot) {
     if(m_resources->isStreaming()) {
       auto body = std::make_shared<oatpp::web::protocol::http::outgoing::StreamingBody>(
         m_resources->getResourceStream("index.html")
@@ -111,7 +118,7 @@ public:
     return createResponse(Status::CODE_200, m_resources->getResource("index.html"));
   }
   
-  ENDPOINT("GET", "/swagger/{filename}", getUIResource, PATH(String, filename)) {
+  ENDPOINT("GET", SWAGGER_ROOT_PATH "/{filename}", getUIResource, PATH(String, filename)) {
     if(m_resources->isStreaming()) {
       auto body = std::make_shared<oatpp::web::protocol::http::outgoing::StreamingBody>(
         m_resources->getResourceStream(filename->c_str())

--- a/src/oatpp-swagger/Controller.hpp
+++ b/src/oatpp-swagger/Controller.hpp
@@ -36,13 +36,6 @@
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
 
-#ifndef SWAGGER_ROOT_PATH
-#define SWAGGER_ROOT_PATH "/swagger"
-#endif
-#ifndef SWAGGER_UI_PATH
-#define SWAGGER_UI_PATH "/ui"
-#endif
-
 namespace oatpp { namespace swagger {
 
 /**


### PR DESCRIPTION
**Proposal:** I think it'll be a useful option to allow changing the default Swagger UI path (`/swagger/ui`) during the server configuration.

Usage example:
```
#define SWAGGER_ROOT_PATH "/"
#define SWAGGER_UI_PATH ""
#include "oatpp-swagger/Controller.hpp"

...

router->addController(oatpp::swagger::Controller::createShared(docEndpoints));
```