### PR TITLE
Add defines to target for export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,10 +100,6 @@ message("\n#####################################################################
 
 set(SWAGGER_ROOT_PATH "/swagger" CACHE STRING "Default root path to the Swagger")
 set(SWAGGER_UI_PATH "/ui" CACHE STRING "Default path suffix to the Swagger UI")
-add_compile_definitions(
-    SWAGGER_ROOT_PATH="${SWAGGER_ROOT_PATH}"
-    SWAGGER_UI_PATH="${SWAGGER_UI_PATH}"
-)
 
 include(cmake/module-utils.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,11 @@ target_include_directories(${OATPP_THIS_MODULE_NAME}
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
+target_compile_definitions(${OATPP_THIS_MODULE_NAME}
+        PUBLIC SWAGGER_ROOT_PATH="${SWAGGER_ROOT_PATH}"
+        SWAGGER_UI_PATH="${SWAGGER_UI_PATH}"
+)
+
 ## TODO link dependencies here (if some)
 
 #######################################################################################################


### PR DESCRIPTION
Fixes issue #61 some dependent packages face when using the lib. This exports the defines via the exported cmake config.

Another example facing the same issue was example-postgresql.