### PR TITLE
Configure controller paths dynamically - improves (#58)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,13 +98,6 @@ message("\n#####################################################################
 ###################################################################################################
 ## define targets
 
-set(SWAGGER_ROOT_PATH "/swagger" CACHE STRING "Default root path to the Swagger")
-set(SWAGGER_UI_PATH "/ui" CACHE STRING "Default path suffix to the Swagger UI")
-add_compile_definitions(
-    SWAGGER_ROOT_PATH="${SWAGGER_ROOT_PATH}"
-    SWAGGER_UI_PATH="${SWAGGER_UI_PATH}"
-)
-
 include(cmake/module-utils.cmake)
 
 include(cmake/msvc-runtime.cmake)

--- a/README.md
+++ b/README.md
@@ -113,14 +113,6 @@ endif()
 include_directories(${oatpp_INCLUDE_DIRS})
 include_directories(${oatpp-swagger_INCLUDE_DIRS})
 
-set(SWAGGER_ROOT_PATH "/swagger" CACHE STRING "Default root path to the Swagger")
-set(SWAGGER_UI_PATH "/ui" CACHE STRING "Default path suffix to the Swagger UI")
-
-add_compile_definitions(
-    SWAGGER_ROOT_PATH="${SWAGGER_ROOT_PATH}"
-    SWAGGER_UI_PATH="${SWAGGER_UI_PATH}"
-)
-
 add_definitions( 
   -DOATPP_SWAGGER_RES_PATH="${OATPP_BASE_DIR}/bin/oatpp-swagger/res"
 )
@@ -131,5 +123,24 @@ target_link_libraries (project PUBLIC
    PUBLIC oatpp::oatpp-swagger
 )
 ```
+
+### Customise Swagger UI Paths
+
+To customise swagger UI endpoints paths add the following component:
+
+```c++
+  /**
+   *  Swagger Controller Paths
+   */
+  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::ControllerPaths>, controllerPaths)([] {
+    auto paths = std::make_shared<oatpp::swagger::ControllerPaths>();
+    paths->apiJson = "custom/path/for/api.json";       // default is "api-docs/oas-3.0.0.json"
+    paths->ui = "my/custom/path/swagger-ui";           // default is "swagger/ui"
+    paths->uiResources = "my/custom/path/{filename}";  // default is "swagger/{filename}"
+    return paths;
+  }());
+```
+
+**NOTE:** `paths->ui` and `paths->uiResources` MUST have the same base path - as shown above.
 
 **Done!**

--- a/res/index.html
+++ b/res/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/api-docs/oas-3.0.0.json",
+        url: "/%%API.JSON%%",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(${OATPP_THIS_MODULE_NAME}
         oatpp-swagger/AsyncController.hpp
         oatpp-swagger/Controller.hpp
+        oatpp-swagger/ControllerPaths.hpp
         oatpp-swagger/Generator.cpp
         oatpp-swagger/Generator.hpp
         oatpp-swagger/Model.hpp
@@ -9,8 +10,7 @@ add_library(${OATPP_THIS_MODULE_NAME}
         oatpp-swagger/Resources.hpp
         oatpp-swagger/Types.cpp
         oatpp-swagger/Types.hpp
-        oatpp-swagger/oas3/Model.hpp
-)
+        oatpp-swagger/oas3/Model.hpp)
 
 set_target_properties(${OATPP_THIS_MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/src/oatpp-swagger/ControllerPaths.hpp
+++ b/src/oatpp-swagger/ControllerPaths.hpp
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi, <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_swagger_ControllerPaths_hpp
+#define oatpp_swagger_ControllerPaths_hpp
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace swagger {
+
+/**
+ * Swagger Controller endpoints paths.
+ */
+struct ControllerPaths {
+
+  /**
+   * Path to generated API JSON.
+   */
+  oatpp::String apiJson = "api-docs/oas-3.0.0.json";
+
+  /**
+   * Path to swagger UI (index.html).
+   */
+  oatpp::String ui = "swagger/ui";
+
+  /**
+   * Path to other ui resources. MUST contain `/{filename}` at the end.
+   */
+  oatpp::String uiResources = "swagger/{filename}";
+
+};
+
+}}
+
+#endif //oatpp_swagger_ControllerPaths_hpp


### PR DESCRIPTION
### Customise Swagger UI Paths

To customise swagger UI endpoints paths add the following component:

```c++
  /**
   *  Swagger Controller Paths
   */
  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::ControllerPaths>, controllerPaths)([] {
    auto paths = std::make_shared<oatpp::swagger::ControllerPaths>();
    paths->apiJson = "custom/path/for/api.json";       // default is "api-docs/oas-3.0.0.json"
    paths->ui = "my/custom/path/swagger-ui";           // default is "swagger/ui"
    paths->uiResources = "my/custom/path/{filename}";  // default is "swagger/{filename}"
    return paths;
  }());
```

**NOTE:** `paths->ui` and `paths->uiResources` MUST have the same base path - as shown above.