### PR TITLE
add cpack file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,3 +109,8 @@ if(OATPP_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()
+
+include(cpack.cmake)
+
+# This must always be last!
+include( CPack )

--- a/cpack.cmake
+++ b/cpack.cmake
@@ -1,0 +1,76 @@
+#
+# Packaging
+# https://cmake.org/cmake/help/latest/module/CPack.html
+#
+
+set( CPACK_PACKAGE_NAME ${PROJECT_NAME} )
+set( CPACK_PACKAGE_VENDOR "oatpp" )
+set( CPACK_PACKAGE_DESCRIPTION_SUMMARY "oatpp-swagger - swagger ui plugin for oatpp" )
+set( CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/oatpp/oatpp-swagger" )
+set( CPACK_PACKAGE_CONTACT      "https://github.com/oatpp/oatpp-swagger" )
+set( CPACK_PACKAGE_VERSION ${OATPP_THIS_MODULE_VERSION} ) 
+set( CPACK_PACKAGE_INSTALL_DIRECTORY ${PROJECT_NAME} )
+get_filename_component( oatpp_root_dir ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY )
+set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE" )
+set( CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md" )
+
+set( CPACK_COMPONENT_Library_DISPLAY_NAME "oatpp-swagger Library" )
+set( CPACK_COMPONENT_Library_DESCRIPTION "The oatpp-swagger binary library." )
+set( CPACK_COMPONENT_Library_REQUIRED 1 )
+
+if( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
+
+    if ( "${CPACK_PACKAGE_ARCHITECTURE}" STREQUAL "" )
+        # Note: the architecture should default to the local architecture, but it
+        # in fact comes up empty.  We call `uname -m` to ask the kernel instead.
+        EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE CPACK_PACKAGE_ARCHITECTURE )
+    endif()
+
+    set( CPACK_INCLUDE_TOPLEVEL_DIRECTORY 1 )
+    set( CPACK_PACKAGE_RELEASE 1 )
+
+    # RPM - https://cmake.org/cmake/help/latest/cpack_gen/rpm.html
+    set( CPACK_RPM_PACKAGE_RELEASE ${CPACK_PACKAGE_RELEASE} )
+    set( CPACK_RPM_PACKAGE_ARCHITECTURE ${CPACK_PACKAGE_ARCHITECTURE} )
+    set( CPACK_RPM_PACKAGE_DESCRIPTION ${CPACK_PACKAGE_DESCRIPTION_SUMMARY} )
+    set( CPACK_RPM_PACKAGE_URL ${CPACK_PACKAGE_HOMEPAGE_URL} )
+    set( CPACK_RPM_PACKAGE_LICENSE "APACHE-2" )
+    set( CPACK_RPM_COMPONENT_INSTALL 1 )
+    set( CPACK_RPM_MAIN_COMPONENT "Library" )
+    set( CPACK_RPM_COMPRESSION_TYPE "xz" )
+    set( CPACK_RPM_PACKAGE_AUTOPROV 1 )
+    set( CPACK_RPM_PACKAGE_NAME "${CPACK_PACKAGE_NAME}" )
+    set( CPACK_RPM_FILE_NAME "RPM-DEFAULT" )
+
+    set( CPACK_RPM_Library_PACKAGE_REQUIRES "cmake >= ${CMAKE_MINIMUM_REQUIRED_VERSION},oatpp >= ${CPACK_PACKAGE_VERSION}" )
+    set( CPACK_RPM_Library_PACKAGE_ARCHITECTURE ${CPACK_PACKAGE_ARCHITECTURE} )
+    set( CPACK_RPM_Library_PACKAGE_NAME ${CPACK_PACKAGE_NAME} )
+    set( CPACK_RPM_Library_FILE_NAME
+         "${CPACK_RPM_Library_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}.${CPACK_RPM_Library_PACKAGE_ARCHITECTURE}.rpm" )
+    set( CPACK_RPM_Library_PACKAGE_SUMMARY ${CPACK_COMPONENT_Library_DESCRIPTION} )
+
+    # DEB - https://cmake.org/cmake/help/latest/cpack_gen/deb.html
+    set( CPACK_DEBIAN_PACKAGE_NAME "${CPACK_PACKAGE_NAME}-dev" )
+    set( CPACK_DEBIAN_PACKAGE_RELEASE ${CPACK_PACKAGE_RELEASE} )
+    set( CPACK_DEBIAN_PACKAGE_HOMEPAGE ${CPACK_PACKAGE_HOMEPAGE_URL} )
+    set( CPACK_DEB_COMPONENT_INSTALL 1 )
+    set( CPACK_DEBIAN_COMPRESSION_TYPE "xz")
+
+    if ( ${CPACK_PACKAGE_ARCHITECTURE} STREQUAL "x86_64" )
+        set( CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64" )  # DEB doesn't always use the kernel's arch name
+    else()
+        set( CPACK_DEBIAN_PACKAGE_ARCHITECTURE ${CPACK_PACKAGE_ARCHITECTURE} )
+    endif()
+
+    set( CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT" ) # Use default naming scheme
+    
+    set( CPACK_DEBIAN_LIBRARY_PACKAGE_DEPENDS "cmake (>= ${CMAKE_MINIMUM_REQUIRED_VERSION}), oatpp (>= ${CPACK_PACKAGE_VERSION})" )
+    set( CPACK_DEBIAN_LIBRARY_PACKAGE_NAME ${CPACK_PACKAGE_NAME} )
+    set( CPACK_DEBIAN_LIBRARY_PACKAGE_SHLIBDEPS 1 )
+    
+elseif( ${CMAKE_HOST_WIN32} )
+    set( CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON )
+    set( CPACK_NSIS_DISPLAY_NAME ${PROJECT_NAME} )
+    set( CPACK_NSIS_PACKAGE_NAME ${PROJECT_NAME} )
+    set( CPACK_NSIS_URL_INFO_ABOUT ${CPACK_PACKAGE_HOMEPAGE_URL} )
+endif()


### PR DESCRIPTION
Since oatpp already has a cpack file but oatpp-swagger has none I added this.
Tested on rocky linux works fine.

Fixes Issue #68

How to build:
cmake 
cmake --build
cpack -G RPM  