### PR TITLE
Fixes #93: Only initialise required field when it isn't empty

### DIFF
--- a/src/oatpp-swagger/Generator.cpp
+++ b/src/oatpp-swagger/Generator.cpp
@@ -130,11 +130,15 @@ oatpp::Object<oas3::Schema> Generator::generateSchemaForTypeObject(const Type* t
       result->properties[p->name] = generateSchemaForType(p->type, true, usedTypes, p, defaultValue);
     }
 
-    result->required = oatpp::List<oatpp::String>::createShared();
+    auto required = oatpp::List<oatpp::String>::createShared();
     for (auto* p : properties->getList()) {
       if (p->info.required) {
-        result->required->push_back(p->name);
+        required->push_back(p->name);
       }
+    }
+
+    if (!required->empty()) {
+      result->required = required;
     }
 
     return result;


### PR DESCRIPTION
Fixes #93.

Only sets the `oas3::Schema`'s required field if there are required values. Having an empty `required` field is against the openapi spec (and causes hundreds of warnings in our API's autogenerated docs). I feel like there's possibly a more elegant way to do do this in C++ but it's not my go-to language, so feel free to suggest something cleaner.