### PR TITLE
Add support for annotated tags and externalDocs

### DIFF
--- a/src/oatpp-swagger/Generator.hpp
+++ b/src/oatpp-swagger/Generator.hpp
@@ -58,6 +58,10 @@ public:
 
   typedef std::unordered_map<oatpp::String, bool> UsedSecuritySchemes;
 
+  typedef std::unordered_map<oatpp::String, bool> UsedTags;
+
+  typedef oatpp::List<Object<oas3::TagItem>> Tags;
+
 private:
   void addParamsToParametersList(const PathItemParameters& paramsList,
                                         Endpoint::Info::Params& params,
@@ -76,12 +80,12 @@ private:
 
   oatpp::Object<oas3::RequestBody> generateRequestBody(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);
   Fields<Object<oas3::OperationResponse>> generateResponses(const Endpoint::Info& endpointInfo, bool linkSchema, UsedTypes& usedTypes);
-  void generatePathItemData(const std::shared_ptr<Endpoint>& endpoint, const oatpp::Object<oas3::PathItem>& pathItem, UsedTypes& usedTypes, UsedSecuritySchemes &usedSecuritySchemes);
+  void generatePathItemData(const std::shared_ptr<Endpoint>& endpoint, const oatpp::Object<oas3::PathItem>& pathItem, UsedTypes& usedTypes, UsedSecuritySchemes &usedSecuritySchemes, UsedTags &usedTags);
   
   /*
    *  UsedTypes& usedTypes is used to put Types of objects whos schema should be reused
    */
-  Paths generatePaths(const Endpoints& endpoints, UsedTypes& usedTypes, UsedSecuritySchemes &usedSecuritySchemes);
+  Paths generatePaths(const Endpoints& endpoints, UsedTypes& usedTypes, UsedSecuritySchemes &usedSecuritySchemes, UsedTags &usedTags);
 
   oatpp::Object<oas3::SecurityScheme> generateSecurityScheme(const std::shared_ptr<oatpp::swagger::SecurityScheme> &ss);
 
@@ -95,6 +99,11 @@ private:
   oatpp::Object<oas3::Components> generateComponents(const UsedTypes &decomposedTypes,
                                                      const std::shared_ptr<std::unordered_map<oatpp::String,std::shared_ptr<oatpp::swagger::SecurityScheme>>> &securitySchemes,
                                                      UsedSecuritySchemes &usedSecuritySchemes);
+
+  Tags generateTags(const std::shared_ptr<std::list<std::shared_ptr<oatpp::swagger::Tag>>> &tags,
+                    const UsedTags &usedTags);
+
+  oatpp::Object<oas3::ExternalDocumentation> generateExternalDocs(const ExternalDocumentation &externalDocs);
 
 public:
 

--- a/src/oatpp-swagger/Model.hpp
+++ b/src/oatpp-swagger/Model.hpp
@@ -871,15 +871,14 @@ public:
      * @return - &l:DocumentInfo::Builder;.
      */
     Builder& setExternalDocsForTag(const oatpp::String& tagName, const oatpp::String& url, const oatpp::String& description ) {
-      auto externalDocs = ExternalDocumentation::createShared();
-      externalDocs->url = url;
-      externalDocs->description = description;
 
       for (auto tag : *getTags())
       {
         if (tag->name == tagName)
         {
-          tag->externalDocs = externalDocs;
+          tag->externalDocs = ExternalDocumentation::createShared();
+          tag->externalDocs->url = url;
+          tag->externalDocs->description = description;
           break;
         }
       }

--- a/src/oatpp-swagger/Model.hpp
+++ b/src/oatpp-swagger/Model.hpp
@@ -306,6 +306,52 @@ struct SecurityScheme {
 };
 
 /**
+ * External documentation object - https://swagger.io/specification/#external-documentation-object .
+ */
+
+struct ExternalDocumentation {
+
+  static std::shared_ptr<ExternalDocumentation> createShared() {
+    return std::make_shared<ExternalDocumentation>();
+  }
+
+  /**
+   * Description
+   */
+  oatpp::String description;
+
+  /**
+   * Url
+   */
+  oatpp::String url;
+};
+
+/**
+ * Tag object - https://swagger.io/specification/#tag-object .
+ */
+struct Tag {
+
+  static std::shared_ptr<Tag> createShared() {
+    return std::make_shared<Tag>();
+  }
+
+  /**
+   * Name
+   */
+  oatpp::String name;
+
+  /**
+   * Description
+   */
+  oatpp::String description;
+
+  /**
+   * External Documentation
+   */
+  std::shared_ptr<ExternalDocumentation> externalDocs;
+};
+
+/**
  * Document Info.
  */
 class DocumentInfo {
@@ -333,6 +379,16 @@ public:
    * Map of &id:oatpp::String; to &l:SecurityScheme;.
    */
    std::shared_ptr<std::unordered_map<oatpp::String, std::shared_ptr<SecurityScheme>>> securitySchemes;
+
+   /**
+   * List of &l:Tag;.
+   */
+   std::shared_ptr<std::list<std::shared_ptr<Tag>>> tags;
+
+   /**
+   * &l:ExternalDocumentation;.
+   */
+   std::shared_ptr<ExternalDocumentation> externalDocs;
 
   /**
    * SecurityScheme Builder.
@@ -604,6 +660,8 @@ public:
     std::shared_ptr<DocumentHeader> m_header;
     std::shared_ptr<std::list<std::shared_ptr<Server>>> m_servers;
     std::shared_ptr<std::unordered_map<oatpp::String, std::shared_ptr<SecurityScheme>>> m_securitySchemes;
+    std::shared_ptr<ExternalDocumentation> m_externalDocs;
+    std::shared_ptr<std::list<std::shared_ptr<Tag>>> m_tags;
 
   private:
 
@@ -637,6 +695,21 @@ public:
       return m_securitySchemes;
     }
     
+    std::shared_ptr<ExternalDocumentation> getExternalDocs() {
+      if(!m_externalDocs) {
+        m_externalDocs = ExternalDocumentation::createShared();
+      }
+      return m_externalDocs;
+    }
+
+    std::shared_ptr<std::list<std::shared_ptr<Tag>>> getTags() {
+      if (!m_tags)
+      {
+        m_tags = std::make_shared<std::list<std::shared_ptr<Tag>>>();
+      }
+      return m_tags;
+    }
+
   public:
 
     /**
@@ -719,6 +792,11 @@ public:
       return *this;
     }
 
+    Builder& setExternalDocs(const oatpp::String &url, const oatpp::String &description) {
+      getExternalDocs()->url = url;
+      getExternalDocs()->description = description;
+      return *this;
+    }
     /**
      * Set license url.
      * @param url
@@ -771,6 +849,44 @@ public:
     }
 
     /**
+     * Add &l:Tag.
+     * @param name
+     * @param description
+     * @return - &l:DocumentInfo::Builder;.
+     */
+    Builder& addTag(const oatpp::String& name, const oatpp::String& description) {
+      auto tag = Tag::createShared();
+      tag->name = name;
+      tag->description = description;
+
+      getTags()->push_back(tag);
+      return *this;
+    }
+
+     /**
+     * Add &l:ExternalDocumentation to &l:Tag
+     * @param tagname
+     * @param description
+     * @param url
+     * @return - &l:DocumentInfo::Builder;.
+     */
+    Builder& setExternalDocsForTag(const oatpp::String& tagName, const oatpp::String& url, const oatpp::String& description ) {
+      auto externalDocs = ExternalDocumentation::createShared();
+      externalDocs->url = url;
+      externalDocs->description = description;
+
+      for (auto tag : *getTags())
+      {
+        if (tag->name == tagName)
+        {
+          tag->externalDocs = externalDocs;
+          break;
+        }
+      }
+      return *this;
+    }
+
+    /**
      * Build Document Info.
      * @return - &l:DocumentInfo;.
      */
@@ -779,6 +895,8 @@ public:
       document->header = m_header;
       document->servers = m_servers;
       document->securitySchemes = m_securitySchemes;
+      document->tags = m_tags;
+      document->externalDocs = m_externalDocs;
       return document;
     }
     

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -513,6 +513,24 @@ class SecurityScheme : public oatpp::DTO {
 };
 
 /**
+ * ExternalDocumentation object
+ */
+class ExternalDocumentation : public oatpp::DTO {
+  DTO_INIT(ExternalDocumentation, DTO)
+
+  /**
+   * Description.
+   */
+  DTO_FIELD(String, description);
+
+
+  /**
+   * URL
+   */
+  DTO_FIELD(String, url);
+};
+
+/**
  * Operation Response.
  */
 class OperationResponse : public oatpp::DTO {
@@ -597,6 +615,12 @@ class PathItemParameter : public oatpp::DTO {
    */
   DTO_FIELD(Fields<Object<Example>>, examples);
 
+  /**
+   * External documentation.
+   */
+
+   DTO_FIELD(Object<ExternalDocumentation>, externalDocs);
+   
 public:
 
   Object<Example> addExample(const String& title, const Any& value) {
@@ -734,6 +758,29 @@ class Components : public oatpp::DTO {
 
 };
 
+
+/**
+ * Tag item.
+ */
+class TagItem : public oatpp::DTO {
+  DTO_INIT(TagItem, DTO)
+
+  /**
+   * Name.
+   */
+  DTO_FIELD(String, name);
+
+  /**
+   * Description.
+   */
+  DTO_FIELD(String, description);
+
+  /**
+   * Description.
+   */
+  DTO_FIELD(Object<ExternalDocumentation>, externalDocs);
+};
+
 /**
  * Document.
  */
@@ -765,9 +812,19 @@ class Document : public oatpp::DTO {
    * &l:Components;.
    */
   DTO_FIELD(Object<Components>, components);
-  
+
+  /**
+   * List of &l:Tags;.
+   */
+  DTO_FIELD(List<Object<TagItem>>, tags);
+
+  /**
+   * &l:ExternalDocs;.
+   */
+  DTO_FIELD(Object<ExternalDocumentation>, externalDocs);
+
 };
-  
+
 #include OATPP_CODEGEN_END(DTO)
 }}}
 


### PR DESCRIPTION
This adds support for the "tags" element of the root document. This allows tags to have a description and an optional URL for external documentation. This is backwards compatible: Tags which are not explicitly declared via a call to `addTag` are added to the list of tags (but their description will remain empty).

It also adds support for the "externalDocs" element of the root document.

Example usage 
```
/**
 *  General API docs info
 */
OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::swagger::DocumentInfo>, swaggerDocumentInfo)([] {

  oatpp::swagger::DocumentInfo::Builder builder;

  builder
  .setTitle("User entity service")
  .setDescription("CRUD API Example project with swagger docs")
  .setVersion("1.0")
  .setContactName("Ivan Ovsyanochka")
  .setContactUrl("https://oatpp.io/")

  .setLicenseName("Apache License, Version 2.0")
  .setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0")
  .setExternalDocs("https://oatpp.io/docs/modules/oatpp-swagger/", "swagger docs")
  .addServer("http://localhost:8000", "server on localhost")

  .addTag("authentication", "Really important information about the login process")
  .addTag("user", "User-related operations")

  .setExternalDocsForTag("authentication", "https://en.wikipedia.org/wiki/Salt_(cryptography)", "background information")

  return builder.build();

}());
```