### PR TITLE
Implement rich tag objects (as defined by the Swagger specification)

### DIFF
--- a/src/oatpp-swagger/Generator.cpp
+++ b/src/oatpp-swagger/Generator.cpp
@@ -686,7 +686,15 @@ oatpp::Object<oas3::Document> Generator::generateDocument(const std::shared_ptr<
     }
 
   }
-  
+
+  if(docInfo->tags) {
+      document->tags = {};
+
+      for(const auto &it : *docInfo->tags) {
+          document->tags->push_back(oas3::Tag::createFromBaseModel(it));
+      }
+  }
+
   UsedTypes usedTypes;
   UsedSecuritySchemes usedSecuritySchemes;
   document->paths = generatePaths(endpoints, usedTypes, usedSecuritySchemes);

--- a/src/oatpp-swagger/Model.hpp
+++ b/src/oatpp-swagger/Model.hpp
@@ -306,6 +306,59 @@ struct SecurityScheme {
 };
 
 /**
+ * External Documentation object - https://swagger.io/specification/#external-documentation-object
+ */
+struct ExternalDocumentation {
+    /**
+     * Create shared ExternalDocumentation.
+     * @return - 'std::shared_ptr' to ExternalDocumentation.
+     */
+    static std::shared_ptr<ExternalDocumentation> createShared() {
+        return std::make_shared<ExternalDocumentation>();
+    }
+
+    /**
+     * Description.
+     */
+    String description;
+
+    /**
+     * url.
+     */
+    String url;
+
+};
+
+/**
+ * Tag object - https://swagger.io/specification/#tag-object
+ */
+struct Tag {
+    /**
+     * Create shared Tag.
+     * @return - 'std::shared_ptr' to Server.
+     */
+    static std::shared_ptr<Tag> createShared() {
+        return std::make_shared<Tag>();
+    }
+
+    /**
+     * Name.
+     */
+    String name;
+
+    /**
+     * Description.
+     */
+    String description;
+
+    /**
+     * External Documentation Link
+     */
+    std::shared_ptr<ExternalDocumentation> externalDocs;
+
+};
+
+/**
  * Document Info.
  */
 class DocumentInfo {

--- a/src/oatpp-swagger/Model.hpp
+++ b/src/oatpp-swagger/Model.hpp
@@ -387,6 +387,9 @@ public:
    */
    std::shared_ptr<std::unordered_map<oatpp::String, std::shared_ptr<SecurityScheme>>> securitySchemes;
 
+
+   std::shared_ptr<std::list<std::shared_ptr<Tag>>>  tags;
+
   /**
    * SecurityScheme Builder.
    */
@@ -656,6 +659,7 @@ public:
     
     std::shared_ptr<DocumentHeader> m_header;
     std::shared_ptr<std::list<std::shared_ptr<Server>>> m_servers;
+    std::shared_ptr<std::list<std::shared_ptr<Tag>>> m_tags;
     std::shared_ptr<std::unordered_map<oatpp::String, std::shared_ptr<SecurityScheme>>> m_securitySchemes;
 
   private:
@@ -809,6 +813,35 @@ public:
     }
 
     /**
+     * Add rich tag data
+     * @param name
+     * @param description
+     * @param documentationDescription
+     * @param documentationUrl
+     * @return - &l:DocumentInfo::Builder;.
+     */
+    Builder& addTag(const oatpp::String& name,
+                    const oatpp::String& description = "",
+                    const oatpp::String& title = "",
+                    const oatpp::String& url = "") {
+        auto tag = Tag::createShared();
+        tag->name = name;
+        tag->description = description;
+
+        if(!title->empty() && !url->empty()) {
+            tag->externalDocs = ExternalDocumentation::createShared();
+            tag->externalDocs->description = title;
+            tag->externalDocs->url = url;
+        }
+
+        if(!m_tags) {
+            m_tags = std::make_shared<std::list<std::shared_ptr<Tag>>>();
+        }
+        m_tags->push_back(tag);
+        return *this;
+    }
+
+    /**
      * Add &l:SecurityScheme;.
      * When you are using the `AUTHENTICATION()` Endpoint-Macro you must add an [SecurityScheme](https://swagger.io/specification/#securitySchemeObject).
      * For basic-authentication you can use the default &id:oatpp::swagger::DocumentInfo::SecuritySchemeBuilder::DefaultBasicAuthorizationSecurityScheme;.
@@ -832,6 +865,7 @@ public:
       document->header = m_header;
       document->servers = m_servers;
       document->securitySchemes = m_securitySchemes;
+      document->tags = m_tags;
       return document;
     }
     

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -355,34 +355,63 @@ class Schema : public oatpp::DTO {
 /**
  * Tag
  */
+class ExternalDocumentation : public oatpp::DTO {
+    DTO_INIT(ExternalDocumentation, DTO)
+
+    /**
+     * A description of the target documentation. CommonMark syntax MAY be used for rich text representation.
+     */
+    DTO_FIELD(String, description);
+
+    /**
+     * REQUIRED. The URI for the target documentation. This MUST be in the form of a URI.
+     */
+    DTO_FIELD(String, url);
+
+};
+
+
+/**
+ * Tag
+ */
 class Tag : public oatpp::DTO {
     DTO_INIT(Tag, DTO)
 
     /**
-     * Name of tag.
+     * REQUIRED. The name of the tag.
      */
     DTO_FIELD(String, name);
 
     /**
-     * Name of tag.
+     * A description for the tag. CommonMark syntax MAY be used for rich text representation.
      */
-    DTO_FIELD(String, displayName);
+    DTO_FIELD(String, description);
 
     /**
-     * Summary.
+     * Additional external documentation for this tag.
      */
-    DTO_FIELD(String, summary);
+    DTO_FIELD(Object<ExternalDocumentation>, externalDocs);
 
 
     /**
-     * URL.
+     * Create Contact from &id:oatpp::swagger::Tag;.
+     * @param model - &id:oatpp::swagger::Tag;
+     * @return - Contact.
      */
-    DTO_FIELD(String, url);
-
-    /**
-     * Link Name
-     */
-    DTO_FIELD(String, urlName);
+    static Wrapper createFromBaseModel(const std::shared_ptr<oatpp::swagger::Tag>& tag) {
+        if(tag) {
+            auto result = createShared();
+            result->name = tag->name;
+            result->description = tag->description;
+            if(tag->externalDocs) {
+                result->externalDocs = ExternalDocumentation::createShared();
+                result->externalDocs->description = tag->externalDocs->description;
+                result->externalDocs->url = tag->externalDocs->url;
+            }
+            return result;
+        }
+        return nullptr;
+    }
 
 
 };

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -710,7 +710,7 @@ class PathItemOperation : public oatpp::DTO {
   /**
    * List of tags.
    */
-  DTO_FIELD(List<Tag>, tags);
+  DTO_FIELD(List<String>, tags);
 
   /**
    * Map of &id:oatpp::String; to &l:OperationResponse;.
@@ -824,6 +824,11 @@ class Document : public oatpp::DTO {
    * Map of &id:oatpp::String; to &l:PathItem;.
    */
   DTO_FIELD(Fields<Object<PathItem>>, paths);
+
+  /**
+   * List of Tags
+   */
+  DTO_FIELD(List<Object<Tag>>, tags);
 
   /**
    * &l:Components;.

--- a/src/oatpp-swagger/oas3/Model.hpp
+++ b/src/oatpp-swagger/oas3/Model.hpp
@@ -353,6 +353,41 @@ class Schema : public oatpp::DTO {
 };
 
 /**
+ * Tag
+ */
+class Tag : public oatpp::DTO {
+    DTO_INIT(Tag, DTO)
+
+    /**
+     * Name of tag.
+     */
+    DTO_FIELD(String, name);
+
+    /**
+     * Name of tag.
+     */
+    DTO_FIELD(String, displayName);
+
+    /**
+     * Summary.
+     */
+    DTO_FIELD(String, summary);
+
+
+    /**
+     * URL.
+     */
+    DTO_FIELD(String, url);
+
+    /**
+     * Link Name
+     */
+    DTO_FIELD(String, urlName);
+
+
+};
+
+/**
  * Example.
  */
 class Example : public oatpp::DTO {
@@ -646,7 +681,7 @@ class PathItemOperation : public oatpp::DTO {
   /**
    * List of tags.
    */
-  DTO_FIELD(List<String>, tags);
+  DTO_FIELD(List<Tag>, tags);
 
   /**
    * Map of &id:oatpp::String; to &l:OperationResponse;.


### PR DESCRIPTION
This allows for the use of the [TagOject](https://swagger.io/specification/#tag-object) and [ExternalDocumentation](https://swagger.io/specification/#external-documentation-object) objects to be passed out to the swagger api.